### PR TITLE
Add Jaguar Serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ main() {
 * [`package:build_value`](https://pub.dartlang.org/packages/built_value)
 * [`package:owl`](https://pub.dartlang.org/packages/owl)
 * [`package:streamy`](https://pub.dartlang.org/packages/streamy)
+* [`package:jaguar_serializer`](https://pub.dartlang.org/packages/jaguar_serializer)
 
 ### Use javascript interop
 


### PR DESCRIPTION
Jaguar Serializer use `build` and `source_gen` package to generate Serializers and provide an Api that simplify the usage of those Serializers (`Repository`, embeded type, not json only)

https://github.com/Jaguar-dart/jaguar_serializer